### PR TITLE
linux-raspberrypi: support improved CVE report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,22 +45,11 @@ pipeline {
                                 kas-container build kas/${MACHINE}.yaml:kas/cve.yaml 2>&1 | tee logs/build_${MACHINE}.log
                             """
 
-                            script {
-                                // Raspberry PI doesn't work with the debug sources, so use the spdx instead
-                                if (MACHINE == 'raspberrypi3-64') {
-                                    sh "python3 layers/openembedded-core/scripts/contrib/improve_kernel_cve_report.py \
-                                            --spdx build/tmp/deploy/spdx/3.0.1/raspberrypi3_64/recipes/recipe-linux-raspberrypi.spdx.json \
-                                            --datadir vulns \
-                                            --old-cve-report build/tmp/log/cve/cve-summary.json \
-                                            --new-cve-report build/tmp/log/cve/cve-summary-enhance_${MACHINE}.json"
-                                } else {
-                                    sh "python3 layers/openembedded-core/scripts/contrib/improve_kernel_cve_report.py \
-                                            --debug-sources build/tmp/pkgdata/${MACHINE}/debugsources/linux-yocto-debugsources.json.zstd \
-                                            --datadir vulns \
-                                            --old-cve-report build/tmp/log/cve/cve-summary.json \
-                                            --new-cve-report build/tmp/log/cve/cve-summary-enhance_${MACHINE}.json"
-                                }
-                            }
+                            sh "python3 layers/openembedded-core/scripts/contrib/improve_kernel_cve_report.py \
+                                    --debug-sources build/tmp/pkgdata/${MACHINE}/debugsources/linux-*-debugsources.json.zstd \
+                                    --datadir vulns \
+                                    --old-cve-report build/tmp/log/cve/cve-summary.json \
+                                    --new-cve-report build/tmp/log/cve/cve-summary-enhance_${MACHINE}.json"
 
                             // Want to use the enhanced report, but new CVEs that do not have a score trip up the plugin.
                             recordIssues(

--- a/README.md
+++ b/README.md
@@ -30,12 +30,7 @@ $ kas-container build kas/<machine>.yaml:kas/sdk.yaml
 
 ```bash
 $ kas-container build --update kas/<machine>.yaml:kas/cve.yaml
-
-# For genericx86-64
-$ python3 layers/openembedded-core/scripts/contrib/improve_kernel_cve_report.py --debug-sources build/tmp/pkgdata/genericx86-64/debugsources/linux-yocto-debugsources.json.zstd --datadir vulns --old-cve-report build/tmp/log/cve/cve-summary.json --new-cve-report build/tmp/log/cve/cve-summary-enhance.json
-
-# For raspberrypi3-64
-$ python3 layers/openembedded-core/scripts/contrib/improve_kernel_cve_report.py --spdx build/tmp/deploy/spdx/3.0.1/raspberrypi3_64/recipes/recipe-linux-raspberrypi.spdx.json --datadir vulns --old-cve-report build/tmp/log/cve/cve-summary.json --new-cve-report build/tmp/log/cve/cve-summary-enhance.json
+$ python3 layers/openembedded-core/scripts/contrib/improve_kernel_cve_report.py --debug-sources build/tmp/pkgdata/<machine>/debugsources/linux-*-debugsources.json.zstd --datadir vulns --old-cve-report build/tmp/log/cve/cve-summary.json --new-cve-report build/tmp/log/cve/cve-summary-enhance.json
 ```
 
 ## Run on QEMU

--- a/kas/cve.yaml
+++ b/kas/cve.yaml
@@ -12,5 +12,4 @@ repos:
 
 local_conf_header:
   enable_cve_check: |
-    SPDX_INCLUDE_COMPILED_SOURCES:pn-linux-yocto = "1"
     INHERIT += "cve-check"

--- a/layers/meta-yald/dynamic-layers/rpi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
+++ b/layers/meta-yald/dynamic-layers/rpi/recipes-kernel/linux/linux-raspberrypi_6.12.bbappend
@@ -1,2 +1,5 @@
 # Clear out PE to normalize kernel version
 PE = ""
+
+# Required by improve_kernel_cve_report.py
+KERNEL_FEATURES:append = " features/debug/debug-kernel.scc"


### PR DESCRIPTION
Needed to turn on debug sources for rpi.